### PR TITLE
Don't allow the HiveMetastore service to start if it's configured in local/embedded mode

### DIFF
--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -8853,8 +8853,9 @@ public class HiveMetaStore extends ThriftHiveMetastore {
       // It doesn't check whether the msUri is valid.
       boolean localMetaStore = MetastoreConf.isEmbeddedMetaStore(msUri);
       if (localMetaStore) {
-        throw new MetaException("Local/Embedded metastore is not allowed. Please configure "
-            + ConfVars.THRIFT_URIS + "; it is currently set to [" + msUri + "]");
+        throw new MetaException("Local/Embedded metastore is not allowed. Please configure '"
+            + ConfVars.THRIFT_URIS.getVarname() + "' or '" + ConfVars.THRIFT_URIS.getHiveName() +
+            "'; it is currently set to [" + msUri + "]");
       }
 
       Lock startLock = new ReentrantLock();

--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -8848,6 +8848,15 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         }
       }
 
+      String msUri = MetastoreConf.getVar(conf, ConfVars.THRIFT_URIS);
+      // Checks whether msUri is null or empty.
+      // It doesn't check whether the msUri is valid.
+      boolean localMetaStore = MetastoreConf.isEmbeddedMetaStore(msUri);
+      if (localMetaStore) {
+        throw new MetaException("Local/Embedded metastore is not allowed. Please configure "
+            + ConfVars.THRIFT_URIS + "; it is currently set to [" + msUri + "]");
+      }
+
       Lock startLock = new ReentrantLock();
       Condition startCondition = startLock.newCondition();
       AtomicBoolean startedServing = new AtomicBoolean();


### PR DESCRIPTION
If the config isn't set, this is the log output

```
Starting hive metastore on port 9083
Exception in thread "main" MetaException(message:Local/Embedded metastore is not allowed. Please configure metastore.thrift.uris; it is currently set to [])
	at org.apache.hadoop.hive.metastore.HiveMetaStore.main(HiveMetaStore.java:8854)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.util.RunJar.run(RunJar.java:328)
	at org.apache.hadoop.util.RunJar.main(RunJar.java:241)
Shutting down hive metastore.
```

This change is checking if the config is set or not. It's not checking whether the config is valid.