### PR TITLE
Fix dependency conflict with HikariCP dependency coming from Hadoop

### DIFF
--- a/hcatalog/core/pom.xml
+++ b/hcatalog/core/pom.xml
@@ -237,6 +237,10 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP-java7</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/itests/hcatalog-unit/pom.xml
+++ b/itests/hcatalog-unit/pom.xml
@@ -208,6 +208,12 @@
       <version>${hadoop.version}</version>
       <scope>test</scope>
       <classifier>tests</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP-java7</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/itests/hive-unit/pom.xml
+++ b/itests/hive-unit/pom.xml
@@ -429,6 +429,12 @@
       <version>${hadoop.version}</version>
       <scope>test</scope>
       <classifier>tests</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP-java7</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/itests/qtest-accumulo/pom.xml
+++ b/itests/qtest-accumulo/pom.xml
@@ -250,6 +250,12 @@
       <version>${hadoop.version}</version>
       <scope>test</scope>
       <classifier>tests</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP-java7</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/itests/qtest-spark/pom.xml
+++ b/itests/qtest-spark/pom.xml
@@ -261,6 +261,12 @@
       <version>${hadoop.version}</version>
       <scope>test</scope>
       <classifier>tests</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP-java7</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/itests/qtest/pom.xml
+++ b/itests/qtest/pom.xml
@@ -256,6 +256,12 @@
       <version>${hadoop.version}</version>
       <scope>test</scope>
       <classifier>tests</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP-java7</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/llap-server/pom.xml
+++ b/llap-server/pom.xml
@@ -136,6 +136,10 @@
           <groupId>commmons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP-java7</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/packaging/src/standalone-metastore/compose/hive-metastore-ranger/conf/hive-site.xml
+++ b/packaging/src/standalone-metastore/compose/hive-metastore-ranger/conf/hive-site.xml
@@ -59,6 +59,16 @@
     <value>false</value>
   </property>
 
+  <property>
+    <name>hikari.connectionTimeout</name>
+    <value>60000</value>
+  </property>
+
+  <property>
+    <name>hive.metastore.try.direct.sql</name>
+    <value>true</value>
+  </property>
+
   <!-- Configure Metastore for Storage Based Authorization -->
   <property>
     <name>hive.metastore.pre.event.listeners</name>

--- a/pom.xml
+++ b/pom.xml
@@ -845,6 +845,12 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-yarn-server-web-proxy</artifactId>
         <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP-java7</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hbase</groupId>

--- a/shims/0.23/pom.xml
+++ b/shims/0.23/pom.xml
@@ -189,6 +189,10 @@
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-log4j12</artifactId>
        </exclusion>
+       <exclusion>
+         <groupId>com.zaxxer</groupId>
+         <artifactId>HikariCP-java7</artifactId>
+       </exclusion>
      </exclusions>
    </dependency>
    <dependency>
@@ -208,6 +212,10 @@
        <exclusion>
          <groupId>com.codahale.metrics</groupId>
          <artifactId>metrics-core</artifactId>
+       </exclusion>
+       <exclusion>
+         <groupId>com.zaxxer</groupId>
+         <artifactId>HikariCP-java7</artifactId>
        </exclusion>
      </exclusions>
    </dependency>

--- a/shims/scheduler/pom.xml
+++ b/shims/scheduler/pom.xml
@@ -81,6 +81,10 @@
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-log4j12</artifactId>
        </exclusion>
+       <exclusion>
+         <groupId>com.zaxxer</groupId>
+         <artifactId>HikariCP-java7</artifactId>
+       </exclusion>
      </exclusions>
    </dependency>
    <dependency>
@@ -93,6 +97,10 @@
        <exclusion>
          <groupId>com.codahale.metrics</groupId>
          <artifactId>metrics-core</artifactId>
+       </exclusion>
+       <exclusion>
+         <groupId>com.zaxxer</groupId>
+         <artifactId>HikariCP-java7</artifactId>
        </exclusion>
      </exclusions>
    </dependency>


### PR DESCRIPTION
I've added the hikari config to the `hive-site.xml` to make sure that we are using it.

I've tested the dependency changes by running `mvn dependency:tree | grep 'HikariCP-java7'`

* `branch-3.1-build-fixed`
    ```
    > mvn dependency:tree | grep 'HikariCP-java7'
    [INFO] |  |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:compile
    [INFO] |  |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:compile
    [INFO] |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |  |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:compile
    [INFO] |  |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:compile
    [INFO] |  |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |  |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:provided
    [INFO] |  |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    [INFO] |  |     |  +- com.zaxxer:HikariCP-java7:jar:2.4.12:runtime
    ```

* this branch
  * the output is empty